### PR TITLE
BadDataException если SimpleXML не смог разобрать данные

### DIFF
--- a/src/YandexXml/Exceptions/BadDataException.php
+++ b/src/YandexXml/Exceptions/BadDataException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AntonShevchuk\YandexXml\Exceptions;
+
+/**
+ * Class BadDataException to work with YandexXml
+ *
+ * @author   gobzer <gobzer@gmail.com>
+ *
+ * @package  YandexXml
+ */
+class BadDataException extends \Exception
+{
+  public $bad_data;
+  public function __construct($bad_data,$message='', $code = 0, Exception $previous = null) {
+    $this->bad_data = $bad_data;
+    parent::__construct($message, $code, $previous);
+  }
+}

--- a/src/YandexXml/Request.php
+++ b/src/YandexXml/Request.php
@@ -872,8 +872,13 @@ class Request
         }
 
         $data = curl_exec($ch);
-
-        $simpleXML = new \SimpleXMLElement($data);
+        try {
+          $simpleXML = new \SimpleXMLElement($data);
+        } catch (Exception $e) {
+          throw new BadDataException($data,$e->getMessage(),$e->getCode(),$e->getPrevious());
+        }
+        
+        
 
         /** @var \SimpleXMLElement $simpleXML */
         $simpleXML = $simpleXML->response;

--- a/src/YandexXml/Request.php
+++ b/src/YandexXml/Request.php
@@ -872,15 +872,13 @@ class Request
         }
 
         $data = curl_exec($ch);
+        /** @var \SimpleXMLElement $simpleXML */
         try {
           $simpleXML = new \SimpleXMLElement($data);
         } catch (Exception $e) {
           throw new BadDataException($data,$e->getMessage(),$e->getCode(),$e->getPrevious());
         }
-        
-        
 
-        /** @var \SimpleXMLElement $simpleXML */
         $simpleXML = $simpleXML->response;
 
         // check response error


### PR DESCRIPTION
Прокси или Яндекс могут выдать не-XML данные. Тогда SimpleXML выкидывает общий Exception. Это уточнение позволяет разобрать такие ситуации на уровне скрипта или отдебажить этот момент.